### PR TITLE
Allow to set tooltips as fullwidth

### DIFF
--- a/src/components/CopilotModal.js
+++ b/src/components/CopilotModal.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { Component } from 'react';
-import { Animated, Easing, View, NativeModules, Modal, StatusBar, Platform } from 'react-native';
+import { Animated, Easing, View, NativeModules, Modal, StatusBar, Platform, Dimensions } from 'react-native';
 import Tooltip from './Tooltip';
 import StepNumber from './StepNumber';
 import styles, { MARGIN, ARROW_SIZE, STEP_NUMBER_DIAMETER, STEP_NUMBER_RADIUS } from './style';
@@ -26,6 +26,8 @@ type Props = {
   backdropColor: string,
   labels: Object,
   svgMaskPath?: SvgMaskPathFn,
+  fullWidthTooltips?: boolean,
+  fullWidthTooltipsHorizontalPadding?: number,
 };
 
 type State = {
@@ -38,6 +40,8 @@ type State = {
     height: number,
   },
 };
+
+const WINDOW_WIDTH: number = Dimensions.get('window').width;
 
 const noop = () => {};
 
@@ -55,6 +59,7 @@ class CopilotModal extends Component<Props, State> {
     androidStatusBarVisible: false,
     backdropColor: 'rgba(0, 0, 0, 0.4)',
     labels: {},
+    fullWidthTooltips: false,
   };
 
   state = {
@@ -154,6 +159,15 @@ class CopilotModal extends Component<Props, State> {
       tooltip.left = tooltip.left === 0 ? tooltip.left + MARGIN : tooltip.left;
       tooltip.maxWidth = layout.width - tooltip.left - MARGIN;
       arrow.left = tooltip.left + MARGIN;
+    }
+
+    if (this.props.fullWidthTooltips) {
+      let margin = this.props.fullWidthTooltipsHorizontalPadding === undefined
+        ? MARGIN
+        : this.props.fullWidthTooltipsHorizontalPadding;
+      tooltip.maxWidth = WINDOW_WIDTH - (2 * margin);
+      tooltip.left = margin;
+      tooltip.right = margin;
     }
 
     const animate = {

--- a/src/hocs/copilot.js
+++ b/src/hocs/copilot.js
@@ -40,6 +40,8 @@ const copilot = ({
   svgMaskPath,
   verticalOffset = 0,
   wrapperStyle,
+  fullWidthTooltips,
+  fullWidthTooltipsHorizontalPadding,
 } = {}) =>
   (WrappedComponent) => {
     class Copilot extends Component<any, State> {
@@ -200,6 +202,8 @@ const copilot = ({
               backdropColor={backdropColor}
               svgMaskPath={svgMaskPath}
               ref={(modal) => { this.modal = modal; }}
+              fullWidthTooltips={fullWidthTooltips}
+              fullWidthTooltipsHorizontalPadding={fullWidthTooltipsHorizontalPadding}
             />
           </View>
         );


### PR DESCRIPTION
When tooltips are pointed for an object close to the middle, the tooltip
bubble becomes very small, which makes it hard to read when there's
quite some text.

![Image-1](https://user-images.githubusercontent.com/3427665/64598919-d3101300-d3b8-11e9-855f-23e1f18d0ecf.png)

---

Unfortunately I couldn't run the tests, they kept failing on my machine.